### PR TITLE
use .get instead of bracket for notation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ pluggy==0.13.1
 pockets==0.9.1
 py==1.10.0
 Pygments==2.9.0
-pyinotify==0.9.6
 pyparsing==2.4.7
 pytest==6.2.4
 pytz==2021.1

--- a/ruly/evaluator.py
+++ b/ruly/evaluator.py
@@ -22,11 +22,12 @@ def backward_chain(knowledge_base, output_name, post_eval_cb=None, **kwargs):
     Returns:
         Dict[str, Any]: state containing calculated values
     """
+    kb_set = knowledge_base.input_variables.union(knowledge_base.derived_variables)
     state = {
-        name: kwargs.get(name)
-        for name in knowledge_base.input_variables.union(
-            knowledge_base.derived_variables)}
-    if state[output_name] is not None:
+        name: kwargs.get(name) for name in kb_set
+    }
+
+    if state.get(output_name) is not None:
         return state
 
     fired_rules = []


### PR DESCRIPTION
Remove  pyinotify
Use get() notation instead of bracket notation to derive the state name.